### PR TITLE
Fixes. Added phraseology+phonetics

### DIFF
--- a/grammar/lexicology/stylistics/nrel_antonym/nrel_antonym.scs
+++ b/grammar/lexicology/stylistics/nrel_antonym/nrel_antonym.scs
@@ -24,7 +24,7 @@ nrel_antonym
         <= nrel_using_constants: ...
         (*
             -> word;;
-            -> sound;;
+            -> sounding;;
             -> different;;
             -> opposite_meaning;;
         *);;
@@ -32,7 +32,7 @@ nrel_antonym
         <=nrel_using_constants:
         {
          word;
-         sound;
+         sounding;
          different;
          opposite_meaning
         };;

--- a/grammar/lexicology/word/soung_reflecting_word.scs
+++ b/grammar/lexicology/word/soung_reflecting_word.scs
@@ -13,8 +13,7 @@ sound_reflecting_word
 
 sc_node_not_relation
 
- -> changeable_word (*=> nrel_main_idtf: [неизменяемое слово] (* <- lang_ru;; *);;*);
-->sound(*=> nrel_main_idtf: [звук] (* <- lang_ru;; *);;*);;
+ -> changeable_word (*=> nrel_main_idtf: [неизменяемое слово] (* <- lang_ru;; *);;*);;
 
 
 definition -> ...   

--- a/grammar/phonetics/accent/accent.scs
+++ b/grammar/phonetics/accent/accent.scs
@@ -1,0 +1,43 @@
+accent
+<-sc_node_not_relation;;
+accent => nrel_main_idtf:
+	[ударение](* <-lang_ru;; *);
+    [accent](* <-lang_en;; *);;
+accent <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: ударение] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: accent] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Выделение каким-либо акустическим средством одного из компонентов речи. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Allocation by any acoustic means of one of speech components.](*<- lang_en;;*);;
+			*);;
+		*);;
+accent-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [побе’да](*<- lang_ru;;*);;
+    *);;
+
+accent <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку типа](*<-lang_ru;; *);
+		[Subdividing based on type](*<-lang_en;; *);;
+	-> verbal_accent; dynamic_accent; clock_accent; phrase_accent;;
+*);;
+accent <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку образования формы одного и того же слова: ](*<-lang_ru;; *);
+		[Subdividing based on formations of a form of the same word:](*<-lang_en;; *);;
+	-> mobile_accent; motionless_accent;;
+*);;
+

--- a/grammar/phonetics/accent/clock_accent.scs
+++ b/grammar/phonetics/accent/clock_accent.scs
@@ -1,0 +1,30 @@
+clock_accent
+<-sc_node_not_relation;;
+clock_accent => nrel_main_idtf:
+	[тактовое ударение](* <-lang_ru;; *);
+    [clock accent](* <-lang_en;; *);;
+clock_accent <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: тактовое ударение] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: clock accent] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Тактовым ударением называется выделение в произношении более важного в смысловом отношении слова в пределах речевого такта. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Clock accent is called allocation in pronunciation of more important word in the semantic relation within a speech step.](*<- lang_en;;*);;
+			*);;
+        <= nrel_using_constants: ...
+            (*
+                -> word;;
+            *);;
+		*);;
+clock_accent -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [Брожу' ли я вдоль у'лиц шумных, вхожу' ль во многолюдный хра'м, сижу' ль меж ю'ношей безумных, я предаю'сь моим мечта'м](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/accent/dynamic_accent.scs
+++ b/grammar/phonetics/accent/dynamic_accent.scs
@@ -1,0 +1,36 @@
+dynamic_accent
+<-sc_node_not_relation;;
+dynamic_accent => nrel_main_idtf:
+	[динамическое ударение](* <-lang_ru;; *);
+    [dynamic accent](* <-lang_en;; *);;
+dynamic_accent <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: динамическое ударение] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: dynamic accent] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Динамическим ударением называется произношение при котором ударный слог выделяется по сравнению с неударными большей напряженностью артикуляции, в особенности гласного звука.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Dynamic accent is called pronunciation at which the shock syllable is allocated in comparison with unaccented bigger tension of an articulation, in particular a vowel.](*<- lang_en;;*);;
+			*);;
+        <= nrel_using_constants: ...
+            (*
+                -> word;;
+            *);;
+		*);;
+dynamic_accent-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [вы'ход](*<- lang_ru;;*);;
+    *);;
+dynamic_accent-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [уда'р](*<- lang_ru;;*);;
+    *);;
+
+

--- a/grammar/phonetics/accent/mobile_accent.scs
+++ b/grammar/phonetics/accent/mobile_accent.scs
@@ -1,0 +1,30 @@
+mobile_accent
+<-sc_node_not_relation;;
+mobile_accent => nrel_main_idtf:
+	[подвижное ударение](* <-lang_ru;; *);
+    [mobile accent](* <-lang_en;; *);;
+mobile_accent <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: подвижное ударение] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: mobile accent] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Подвижность ударения служит дополнительным средством при образовании форм одного и того же слова: ударение переходит с одной части слова на другую. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The mobility of an accent serves as an additional tool at formation of forms of the same word: the accent passes from one part of a word to another.](*<- lang_en;;*);;
+			*);;
+        <= nrel_using_constants: ...
+            (*
+                -> word;;
+            *);;
+		*);;
+mobile_accent -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [го'род, города', городо'в](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/accent/motionless_accent.scs
+++ b/grammar/phonetics/accent/motionless_accent.scs
@@ -1,0 +1,30 @@
+motionless_accent
+<-sc_node_not_relation;;
+motionless_accent => nrel_main_idtf:
+	[неподвижное ударение](* <-lang_ru;; *);
+    [motionless accent](* <-lang_en;; *);;
+motionless_accent <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: неподвижное ударение] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: motionless accent] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Ударение, которое при образовании форм одного и того же слова переходит с одной части слова на другую. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Accent which at formation of forms of the same word passes from one part of a word to another.](*<- lang_en;;*);;
+			*);;
+        <= nrel_using_constants: ...
+            (*
+                -> word;;
+            *);;
+		*);;
+motionless_accent -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [огоро'д, огоро'да, огоро'ду, огоро'ды, огоро'дов](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/accent/phrase_accent.scs
+++ b/grammar/phonetics/accent/phrase_accent.scs
@@ -1,0 +1,30 @@
+phrase_accent
+<-sc_node_not_relation;;
+phrase_accent => nrel_main_idtf:
+	[фразовое ударение](* <-lang_ru;; *);
+    [phrase accent](* <-lang_en;; *);;
+phrase_accent <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: фразовое ударение] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: phrase accent] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Фразовым ударением называется выделение в произношении наиболее важного в смысловом отношении слова в пределах высказывания. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Phrase accent is called allocation in pronunciation of the most important word in the semantic relation within a statement.](*<- lang_en;;*);;
+			*);;
+        <= nrel_using_constants: ...
+            (*
+                -> word;;
+            *);;
+		*);;
+phrase_accent -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [Брожу ли я вдоль улиц шумных, вхожу ль во многолюдный храм, сижу ль меж юношей безумных, я предаюсь моим 'мечтам' ](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/accent/verbal_accent.scs
+++ b/grammar/phonetics/accent/verbal_accent.scs
@@ -1,0 +1,36 @@
+verbal_accent
+<-sc_node_not_relation;;
+verbal_accent => nrel_main_idtf:
+	[словесное ударение](* <-lang_ru;; *);
+    [verbal accent](* <-lang_en;; *);;
+verbal_accent <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: словесное ударение] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: verbal accent] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Словесным ударением называется выделение при произношении одного из слогов двусложного или многосложного слова. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Verbal accent is called allocation at pronunciation of one of syllables disyllabic or a multisyllable.](*<- lang_en;;*);;
+			*);;
+        <= nrel_using_constants: ...
+            (*
+                -> word;;
+            *);;
+		*);;
+verbal_accent-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [под-горо'й ](*<- lang_ru;;*);;
+    *);;
+verbal_accent-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [на-стороне'](*<- lang_ru;;*);;
+    *);;
+
+

--- a/grammar/phonetics/sound/consonant/affricate_sound.scs
+++ b/grammar/phonetics/sound/consonant/affricate_sound.scs
@@ -1,0 +1,36 @@
+affricate_sound
+<-sc_node_not_relation;;
+affricate_sound => nrel_main_idtf:
+	[аффрикат](* <-lang_ru;; *);
+    [affricate](* <-lang_en;; *);;
+affricate_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: аффрикат] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: affricate] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Согласные звуки, представляющие слитное сочетание взрывного согласного звука с фрикативным того же места образования (т. е. образуемого с помощью тех же органов произношения).](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The consonants representing a conjoint combination of an explosive consonant to fricative the same place of formation (i.e. the pronunciation formed by means of the same bodies).](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> consonant_sound;;
+                -> fricative_sound;;
+            *);;
+		*);;
+
+affricate_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[ц]](*<- lang_ru;;*);;
+    *);;
+affricate_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[ч]](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phonetics/sound/consonant/backtongue_sound.scs
+++ b/grammar/phonetics/sound/consonant/backtongue_sound.scs
@@ -1,0 +1,30 @@
+backtongue_sound
+<-sc_node_not_relation;;
+backtongue_sound => nrel_main_idtf:
+	[заднеязычный звук](* <-lang_ru;; *);
+    [back-tongue sound](* <-lang_en;; *);;
+backtongue_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: заднеязычный звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: back-tongue sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Согласные звуки, образуемые поднятием задней части спинки языка к заднему (мягкому) нёбу или к задней части твердого нёба. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The consonants formed by a raising of a back part of a back of tongue to the back (soft) sky or to a back part of a hard palate.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> consonant_sound;;
+            *);;
+		*);;
+
+backtongue_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[к]](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phonetics/sound/consonant/bouncing_sound.scs
+++ b/grammar/phonetics/sound/consonant/bouncing_sound.scs
@@ -1,0 +1,30 @@
+bouncing_sound
+<-sc_node_not_relation;;
+bouncing_sound => nrel_main_idtf:
+	[дрожащий звук](* <-lang_ru;; *);
+    [bouncing sound](* <-lang_en;; *);;
+bouncing_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: дрожащий звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: bouncing sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Дрожащие звуки - звуки, которые образуются чередованием смычки и прохода.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The shivering sounds are sounds which are formed by alternation bows and pass.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+bouncing_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[р]](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phonetics/sound/consonant/consonant_sound.scs
+++ b/grammar/phonetics/sound/consonant/consonant_sound.scs
@@ -1,0 +1,85 @@
+consonant_sound
+<-sc_node_not_relation;;
+consonant_sound => nrel_main_idtf:
+	[согласный звук](* <-lang_ru;; *);
+    [consonant sound](* <-lang_en;; *);;
+consonant_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: согласный звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: consonant sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук, состоящий только из голоса (музыкального тона). ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The sound consisting only of a voice (musical tone).](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+consonant_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[б]](*<- lang_ru;;*);;
+    *);;
+consonant_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[м]](*<- lang_ru;;*);;
+    *);;
+consonant_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[р]](*<- lang_ru;;*);;
+    *);;
+
+consonant_sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку парности - непарности:](*<-lang_ru;; *);
+		[Subdividing based on paired relationship - not paired relationship:](*<-lang_en;; *);;
+	-> paired_sound; not_paired_sound;;
+*);;
+
+consonant_sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку твёрдости - мягкости: ](*<-lang_ru;; *);
+		[Subdividing based on hardness - softness:](*<-lang_en;; *);;
+	-> solid_sound; soft_sound;;
+*);;
+
+consonant_sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку звонкости - глухости: ](*<-lang_ru;; *);
+		[Subdividing based on sonorities - dullness:](*<-lang_en;; *);;
+	-> voiced_sound; dull_sound;;
+*);;
+
+consonant_sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку места образования шума: ](*<-lang_ru;; *);
+		[Subdividing based on places of formation of noise:](*<-lang_en;; *);;
+	-> lip_sound; tongue_sound;;
+*);;
+
+consonant_sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку способа образования шума: ](*<-lang_ru;; *);
+		[Subdividing based on way of formation of noise:](*<-lang_en;; *);;
+	-> occlusive_sound; fricative_sound; affricate_sound; pass_sound; bouncing_sound;;
+*);;

--- a/grammar/phonetics/sound/consonant/dull_sound.scs
+++ b/grammar/phonetics/sound/consonant/dull_sound.scs
@@ -1,0 +1,36 @@
+dull_sound
+<-sc_node_not_relation;;
+dull_sound => nrel_main_idtf:
+	[глухой звук](* <-lang_ru;; *);
+    [dull sound](* <-lang_en;; *);;
+dull_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: глухой звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: dull sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Глухой звук – согласный звук, образуемый при помощи одного шума, без участия голоса. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Dull sound – the consonant formed by means of one noise without participation of a voice.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+                -> consonant_sound;;
+            *);;
+		*);;
+
+dull_sound -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[к]](*<- lang_ru;;*);;
+    *);;
+dull_sound -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[п]](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phonetics/sound/consonant/fricative_sound.scs
+++ b/grammar/phonetics/sound/consonant/fricative_sound.scs
@@ -1,0 +1,35 @@
+fricative_sound
+<-sc_node_not_relation;;
+fricative_sound => nrel_main_idtf:
+	[фрикативный звук](* <-lang_ru;; *);
+    [fricative sound](* <-lang_en;; *);;
+fricative_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: фрикативный звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: fricative sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук, образуемый трением воздуха в щели между сближенными органами речи. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The sound formed by friction of air in a crack between the pulled together organs of speech.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+fricative_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[в]](*<- lang_ru;;*);;
+    *);;
+fricative_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[ф]](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phonetics/sound/consonant/fronttongue_sound.scs
+++ b/grammar/phonetics/sound/consonant/fronttongue_sound.scs
@@ -1,0 +1,34 @@
+fronttongue_sound
+<-sc_node_not_relation;;
+fronttongue_sound => nrel_main_idtf:
+	[переднеязычный звук](* <-lang_ru;; *);
+    [front-tongue sound](* <-lang_en;; *);;
+fronttongue_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: переднеязычный звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: front-tongue sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук, при котором язык доминирует при его образовании.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Sound at which tongue dominates at its formation.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> consonant_sound;;
+            *);;
+		*);;
+
+fronttongue_sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку типа:](*<-lang_ru;; *);
+		[Subdividing based on type:](*<-lang_en;; *);;
+	-> tooth_sound; palataltotooth_sound;;
+*);;
+

--- a/grammar/phonetics/sound/consonant/lip_sound.scs
+++ b/grammar/phonetics/sound/consonant/lip_sound.scs
@@ -1,0 +1,34 @@
+lip_sound
+<-sc_node_not_relation;;
+lip_sound => nrel_main_idtf:
+	[губной звук](* <-lang_ru;; *);
+    [lip sound](* <-lang_en;; *);;
+lip_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: губной звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: lip sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук, при котором губа доминирует при его образовании. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Sound at which the lip dominates at its formation.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+lip_sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку артикуляции:](*<-lang_ru;; *);
+		[Subdividing based on articulation:](*<-lang_en;; *);;
+	-> liptolip_sound; liptotooth_sound;;
+*);;
+

--- a/grammar/phonetics/sound/consonant/liptolip_sound.scs
+++ b/grammar/phonetics/sound/consonant/liptolip_sound.scs
@@ -1,0 +1,34 @@
+liptolip_sound
+<-sc_node_not_relation;;
+liptolip_sound => nrel_main_idtf:
+	[губно-губной звук](* <-lang_ru;; *);
+    [lip to lip sound](* <-lang_en;; *);;
+liptolip_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: губно-губной звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: lip to lip sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук, при котором губа артикулирует к губе.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Sound at which the lip articulates to a lip.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+liptolip_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[м]](*<- lang_ru;;*);;
+    *);;
+liptolip_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[п]](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phonetics/sound/consonant/liptotooth_sound.scs
+++ b/grammar/phonetics/sound/consonant/liptotooth_sound.scs
@@ -1,0 +1,34 @@
+liptotooth_sound
+<-sc_node_not_relation;;
+liptotooth_sound => nrel_main_idtf:
+	[губно-зубной звук](* <-lang_ru;; *);
+    [lip to tooth sound](* <-lang_en;; *);;
+liptotooth_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: губно-зубной звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: lip to tooth sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук, при котором губа артикулирует к зубам.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Sound at which the lip articulates to a tooth.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+liptotooth_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[в]](*<- lang_ru;;*);;
+    *);;
+liptotooth_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[ф]](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phonetics/sound/consonant/middletongue_sound.scs
+++ b/grammar/phonetics/sound/consonant/middletongue_sound.scs
@@ -1,0 +1,26 @@
+middletongue_sound
+<-sc_node_not_relation;;
+middletongue_sound => nrel_main_idtf:
+	[среднеязычный звук](* <-lang_ru;; *);
+    [middle-tongue sound](* <-lang_en;; *);;
+middletongue_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: среднеязычный звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: middle-tongue sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Согласный звук, произносимый при участии средней части спинки языка.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The consonant said with the participation of a middle part of a back of tongue.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> consonant_sound;;
+            *);;
+		*);;
+
+

--- a/grammar/phonetics/sound/consonant/not_paired_sound.scs
+++ b/grammar/phonetics/sound/consonant/not_paired_sound.scs
@@ -1,0 +1,35 @@
+not_paired_sound
+<-sc_node_not_relation;;
+not_paired_sound => nrel_main_idtf:
+	[непарный согласный звук](* <-lang_ru;; *);
+    [not paired consonant sound](* <-lang_en;; *);;
+not_paired_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: непарный согласный звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: not paired consonant sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Непарный согласный звук – это звук, который не имеет пары по различным признакам.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Not paired consonant is a sound which has no couple on various signs.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+not_paired_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[р]](*<- lang_ru;;*);;
+    *);;
+not_paired_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[н]](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phonetics/sound/consonant/occlusive_sound.scs
+++ b/grammar/phonetics/sound/consonant/occlusive_sound.scs
@@ -1,0 +1,35 @@
+occlusive_sound
+<-sc_node_not_relation;;
+occlusive_sound => nrel_main_idtf:
+	[смычной звук](* <-lang_ru;; *);
+    [occlusive](* <-lang_en;; *);;
+occlusive_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: смычной звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: occlusive] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Смычные согласные (окклюзивы) — согласные звуки, при артикуляции которых органы речи находятся в таком положении, что поток воздуха из легких полностью блокируется с помощью смычки, создаваемой в полости рта или в гортани.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Occlusive sounds are consonants at which articulation organs of speech are in such situation that air flow from lungs is completely blocked with the help bows created in an oral cavity or in a throat.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+occlusive_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[г]](*<- lang_ru;;*);;
+    *);;
+occlusive_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[к]](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phonetics/sound/consonant/paired_sound.scs
+++ b/grammar/phonetics/sound/consonant/paired_sound.scs
@@ -1,0 +1,53 @@
+paired_sound
+<-sc_node_not_relation;;
+paired_sound => nrel_main_idtf:
+	[парный согласный звук](* <-lang_ru;; *);
+    [paired consonant sound](* <-lang_en;; *);;
+paired_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: парный согласный звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: paired consonant sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Парный согласный звук – это звук, который имеет пару по различным признакам. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The paired consonant is a sound which has couple on various signs.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+paired_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[п]](*<- lang_ru;;*);;
+    *);;
+paired_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[ш]](*<- lang_ru;;*);;
+    *);;
+
+paired_sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку твёрдости - мягкости: ](*<-lang_ru;; *);
+		[Subdividing based on hardness - softness:](*<-lang_en;; *);;
+	-> hardness_sound; softness_sound;;
+*);;
+
+paired_sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку звонкости - глухости: ](*<-lang_ru;; *);
+		[Subdividing based on sonorities - dullness:](*<-lang_en;; *);;
+	-> sonant_sound; dullness_sound;;
+*);;

--- a/grammar/phonetics/sound/consonant/palataltotooth_sound.scs
+++ b/grammar/phonetics/sound/consonant/palataltotooth_sound.scs
@@ -1,0 +1,30 @@
+palataltotooth_sound
+<-sc_node_not_relation;;
+palataltotooth_sound => nrel_main_idtf:
+	[нёбно-зубной звук](* <-lang_ru;; *);
+    [palatal-tooth sound](* <-lang_en;; *);;
+palataltotooth_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: нёбно-зубной звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: palatal-tooth sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Согласный звук, образующийся поднятием кончика языка к границе передних верхних зубов и нёба.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The consonant which is formed a language tip raising to border of front upper teeth and the palate.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> consonant_sound;;
+            *);;
+		*);;
+
+palataltotooth_sound -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[р]](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phonetics/sound/consonant/pass_sound.scs
+++ b/grammar/phonetics/sound/consonant/pass_sound.scs
@@ -1,0 +1,35 @@
+pass_sound
+<-sc_node_not_relation;;
+pass_sound => nrel_main_idtf:
+	[смычно-проходной звук](* <-lang_ru;; *);
+    [occlusive-pass sound](* <-lang_en;; *);;
+pass_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: смычно-проходной звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: occlusive-pass sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Смычно-проходной звук - звук, при котором одни органы артикуляции образуют смычку, а другие образуют проход для воздушной струи.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Occlusive-pass sound is a sound at which some bodies of an articulation form to a bow and others form pass for an air stream.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+pass_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[л]](*<- lang_ru;;*);;
+    *);;
+pass_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[м]](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phonetics/sound/consonant/soft_sound.scs
+++ b/grammar/phonetics/sound/consonant/soft_sound.scs
@@ -1,0 +1,35 @@
+soft_sound
+<-sc_node_not_relation;;
+soft_sound => nrel_main_idtf:
+	[мягкий звук](* <-lang_ru;; *);
+    [soft sound](* <-lang_en;; *);;
+soft_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: мягкий звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: soft sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Мягкий звук – это звук, образуемый без помощи дополнительной артикуляции. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The soft sound is the sound formed without an additional articulation.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+soft_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[ч]](*<- lang_ru;;*);;
+    *);;
+soft_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[ш]](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phonetics/sound/consonant/solid_sound.scs
+++ b/grammar/phonetics/sound/consonant/solid_sound.scs
@@ -1,0 +1,35 @@
+solid_sound
+<-sc_node_not_relation;;
+solid_sound => nrel_main_idtf:
+	[твердый звук](* <-lang_ru;; *);
+    [solid sound](* <-lang_en;; *);;
+solid_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: твердый звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: solid sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Твёрдый звук – это звук, образуемый при помощи дополнительной артикуляции. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The solid sound is the sound formed by means of an additional articulation.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+solid_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[р]](*<- lang_ru;;*);;
+    *);;
+solid_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[з]](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phonetics/sound/consonant/tongue_sound.scs
+++ b/grammar/phonetics/sound/consonant/tongue_sound.scs
@@ -1,0 +1,34 @@
+tongue_sound
+<-sc_node_not_relation;;
+tongue_sound => nrel_main_idtf:
+	[язычный звук](* <-lang_ru;; *);
+    [tongue sound](* <-lang_en;; *);;
+tongue_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: язычный звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: tongue sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук, при котором язык доминирует при его образовании.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Sound at which tongue dominates at its formation.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+tongue_sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку артикуляции:](*<-lang_ru;; *);
+		[Subdividing based on articulation:](*<-lang_en;; *);;
+	-> fronttongue_sound; middletongue_sound; backtongue_sound;;
+*);;
+

--- a/grammar/phonetics/sound/consonant/tooth_sound.scs
+++ b/grammar/phonetics/sound/consonant/tooth_sound.scs
@@ -1,0 +1,26 @@
+tooth_sound
+<-sc_node_not_relation;;
+tooth_sound => nrel_main_idtf:
+	[зубной звук](* <-lang_ru;; *);
+    [tooth sound](* <-lang_en;; *);;
+tooth_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: зубной звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: tooth sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук, образуемый между языком и верхним рядом зубов.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The sound formed between tongue and the top number of teeth.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+

--- a/grammar/phonetics/sound/consonant/voiced_sound.scs
+++ b/grammar/phonetics/sound/consonant/voiced_sound.scs
@@ -1,0 +1,36 @@
+voiced_sound
+<-sc_node_not_relation;;
+voiced_sound => nrel_main_idtf:
+	[звонкий звук](* <-lang_ru;; *);
+    [voiced sound](* <-lang_en;; *);;
+voiced_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: звонкий звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: voiced sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звонкий звук – согласный звук, образуемый шумом в сопровождении голоса.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Voiced sound – the consonant formed by noise accompanied by a voice.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+                -> consonant_sound;;
+            *);;
+		*);;
+
+voiced_sound -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[ж]](*<- lang_ru;;*);;
+    *);;
+voiced_sound -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[д]](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phonetics/sound/sound.scs
+++ b/grammar/phonetics/sound/sound.scs
@@ -1,0 +1,34 @@
+sound
+<-sc_node_not_relation;;
+sound => nrel_main_idtf:
+	[звук](* <-lang_ru;; *);
+    [sound](* <-lang_en;; *);;
+sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Кратчайшая, минимальная, нечленимая звуковая единица, которая выделяется при последовательном звуковом членении слова. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The shortest, minimum, nechlenimy sound unit which is allocated at consecutive sound partitioning of a word.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> word;;
+            *);;
+		*);;
+
+sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку гласности](*<-lang_ru;; *);
+		[Subdividing based on vowel](*<-lang_en;; *);;
+	-> vowel_sound; consonant_sound;;
+*);;
+

--- a/grammar/phonetics/sound/vowel/accent_sound.scs
+++ b/grammar/phonetics/sound/vowel/accent_sound.scs
@@ -1,0 +1,29 @@
+accent_sound
+<-sc_node_not_relation;;
+accent_sound => nrel_main_idtf:
+	[ударный звук](* <-lang_ru;; *);
+    [accent sound](* <-lang_en;; *);;
+accent_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: ударный звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: accent sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук, на который падает ударение в слове.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Sound on which the accent in a word falls.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+                -> word;;
+                -> accent;;
+            *);;
+		*);;
+
+
+

--- a/grammar/phonetics/sound/vowel/labialized_sound.scs
+++ b/grammar/phonetics/sound/vowel/labialized_sound.scs
@@ -1,0 +1,27 @@
+labialized_sound
+<-sc_node_not_relation;;
+labialized_sound => nrel_main_idtf:
+	[лабиализованный звук](* <-lang_ru;; *);
+    [labialized sound](* <-lang_en;; *);;
+labialized_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: лабиализованный звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: labialized sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Лабиализованный звук — звуки человеческой речи, образуемые с помощью губ. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The labialized sound — the sounds of the human speech formed by means of lips.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+
+

--- a/grammar/phonetics/sound/vowel/not_labialized_sound.scs
+++ b/grammar/phonetics/sound/vowel/not_labialized_sound.scs
@@ -1,0 +1,28 @@
+not_labialized_sound
+<-sc_node_not_relation;;
+not_labialized_sound => nrel_main_idtf:
+	[нелабиализованный звук](* <-lang_ru;; *);
+    [not labialized sound](* <-lang_en;; *);;
+not_labialized_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: нелабиализованный звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: not labialized sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Нелабиализованный звук — долгий гласный звук.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Not labialized sound — long vowel sound.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+                -> vowel_sound;;
+            *);;
+		*);;
+
+
+

--- a/grammar/phonetics/sound/vowel/unaccent_sound.scs
+++ b/grammar/phonetics/sound/vowel/unaccent_sound.scs
@@ -1,0 +1,28 @@
+unaccent_sound
+<-sc_node_not_relation;;
+unaccent_sound => nrel_main_idtf:
+	[безударный звук](* <-lang_ru;; *);
+    [unaccent sound](* <-lang_en;; *);;
+unaccent_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: безударный звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: unaccent sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Гласный в безударном положении находится в слабой позиции, то есть произносится с меньшей силой и менее отчётливо. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Vowel in unaccented situation is in a weak position, that is it is said with a smaller force and it is less distinct.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> accent;;
+                -> vowel_sound;;
+            *);;
+		*);;
+
+
+

--- a/grammar/phonetics/sound/vowel/vowel_back_row.scs
+++ b/grammar/phonetics/sound/vowel/vowel_back_row.scs
@@ -1,0 +1,36 @@
+vowel_back_row
+<-sc_node_not_relation;;
+vowel_back_row => nrel_main_idtf:
+	[гласный звук заднего ряда](* <-lang_ru;; *);
+    [vowel of the back row](* <-lang_en;; *);;
+vowel_back_row <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: гласный звук заднего ряда] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: vowel of the back row] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук при котором основная масса языка сконцентрирована в задней части ротовой полости.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Sound at which the bulk of tongue is concentrated in a back part of a mouth.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+vowel_back_row -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[о]](*<- lang_ru;;*);;
+    *);;
+vowel_back_row -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[у]](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/sound/vowel/vowel_bottom_rise.scs
+++ b/grammar/phonetics/sound/vowel/vowel_bottom_rise.scs
@@ -1,0 +1,32 @@
+vowel_bottom_rise
+<-sc_node_not_relation;;
+vowel_bottom_rise => nrel_main_idtf:
+	[гласный звук нижнего подъема](* <-lang_ru;; *);
+    [vowel of the bottom rise](* <-lang_en;; *);;
+vowel_bottom_rise <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: гласный звук нижнего подъема] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: vowel of the bottom rise] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук при котором язык располагается достаточно низко, расстояние между спинкой языка и небом наибольшее, что достигается и за счет немного опущенной нижней челюсти, поэтому его отличает максимальное среди всех гласных звуков русского языка раскрытия рта .
+](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Sound at which tounge is located rather low, distance between a back of language and the sky the greatest that is reached also at the expense of a little lowered lower jaw therefore distinguishes it maximum among all vowels of Russian of disclosure of a mouth.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+vowel_bottom_rise -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[а]](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/sound/vowel/vowel_front_row.scs
+++ b/grammar/phonetics/sound/vowel/vowel_front_row.scs
@@ -1,0 +1,36 @@
+vowel_front_row
+<-sc_node_not_relation;;
+vowel_front_row => nrel_main_idtf:
+	[гласный звук переднего ряда](* <-lang_ru;; *);
+    [vowel of the front row](* <-lang_en;; *);;
+vowel_front_row <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: гласный звук переднего ряда] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: vowel of the front row] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук при котором язык выдвинут вперед. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Sound at which tongue is pushed forward.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+vowel_front_row -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[е]](*<- lang_ru;;*);;
+    *);;
+vowel_front_row -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[и]](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/sound/vowel/vowel_middle_rise.scs
+++ b/grammar/phonetics/sound/vowel/vowel_middle_rise.scs
@@ -1,0 +1,41 @@
+vowel_middle_rise
+<-sc_node_not_relation;;
+vowel_middle_rise => nrel_main_idtf:
+	[гласный звук среднего подъема](* <-lang_ru;; *);
+    [vowel of the middle rise](* <-lang_en;; *);;
+vowel_middle_rise <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: гласный звук среднего подъема] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: vowel of the middle rise] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук при котором язык занимает среднюю позицию .](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Sound at which tounge takes an average position.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+vowel_middle_rise -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[о]](*<- lang_ru;;*);;
+    *);;
+vowel_middle_rise -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[е]](*<- lang_ru;;*);;
+    *);;
+vowel_middle_rise -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[у]](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/sound/vowel/vowel_middle_row.scs
+++ b/grammar/phonetics/sound/vowel/vowel_middle_row.scs
@@ -1,0 +1,36 @@
+vowel_middle_row
+<-sc_node_not_relation;;
+vowel_middle_row => nrel_main_idtf:
+	[гласный звук среднего ряда](* <-lang_ru;; *);
+    [vowel of the middle row](* <-lang_en;; *);;
+vowel_middle_row <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: гласный звук среднего ряда] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: vowel of the middle row] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук при котором основная масса языка занимает среднее положение.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Sound at which the bulk of tongue holds average position.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+vowel_middle_row -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[а]](*<- lang_ru;;*);;
+    *);;
+vowel_middle_row -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[ы]](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/sound/vowel/vowel_sound.scs
+++ b/grammar/phonetics/sound/vowel/vowel_sound.scs
@@ -1,0 +1,77 @@
+vowel_sound
+<-sc_node_not_relation;;
+vowel_sound => nrel_main_idtf:
+	[гласный звук](* <-lang_ru;; *);
+    [vowel sound](* <-lang_en;; *);;
+vowel_sound <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: гласный звук] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: vowel sound] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук, состоящий только из голоса (музыкального тона). ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The sound consisting only of a voice (musical tone).](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+vowel_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[а]](*<- lang_ru;;*);;
+    *);;
+vowel_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[о]](*<- lang_ru;;*);;
+    *);;
+vowel_sound-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[у]](*<- lang_ru;;*);;
+    *);;
+
+vowel_sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку произнесения:](*<-lang_ru;; *);
+		[Subdividing based on pronouncings:](*<-lang_en;; *);;
+	-> labialized_sound; not_labialized_sound;;
+*);;
+
+vowel_sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку ударности](*<-lang_ru;; *);
+		[Subdividing based on accent](*<-lang_en;; *);;
+	-> accent_sound; unaccent_sound;;
+*);;
+
+vowel_sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку степени вертикального подъема языка](*<-lang_ru;; *);
+		[Subdividing based on extents of vertical raising of tongue](*<-lang_en;; *);;
+	-> vowel_top_rise; vowel_bottom_rise; vowel_middle_rise;;
+*);;
+
+vowel_sound <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку степени вертикального подъема языка](*<-lang_ru;; *);
+		[Subdividing based on extents of vertical raising of tongue](*<-lang_en;; *);;
+	-> vowel_front_row; vowel_back_row; vowel_middle_row;;
+*);;
+

--- a/grammar/phonetics/sound/vowel/vowel_top_rise.scs
+++ b/grammar/phonetics/sound/vowel/vowel_top_rise.scs
@@ -1,0 +1,41 @@
+vowel_top_rise
+<-sc_node_not_relation;;
+vowel_top_rise => nrel_main_idtf:
+	[гласный звук верхнего подъема](* <-lang_ru;; *);
+    [vowel of the top rise](* <-lang_en;; *);;
+vowel_top_rise <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: гласный звук верхнего подъема] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: vowel of the top rise] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Звук при котором язык приподнят ближе всего к небу и даже немного немного отогнут назад .](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The sound at which tounge is raised most closer to the sky and is even a little a little unbent back.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+vowel_top_rise -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[ы]](*<- lang_ru;;*);;
+    *);;
+vowel_top_rise -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[и]](*<- lang_ru;;*);;
+    *);;
+vowel_top_rise -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [[у]](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/syllable/accent_syllable.scs
+++ b/grammar/phonetics/syllable/accent_syllable.scs
@@ -1,0 +1,31 @@
+accent_syllable
+<-sc_node_not_relation;;
+accent_syllable => nrel_main_idtf:
+	[ударный слог](* <-lang_ru;; *);
+    [accent syllable](* <-lang_en;; *);;
+accent_syllable <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: ударный слог] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: accent syllable] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Ударный слог - определенный слог в слове, выделяемый более сильным произношением.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Accent syllable - the certain syllable in a word allocated by stronger pronunciation.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> syllable;;
+            *);;
+		*);;
+
+accent_syllable -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [анатомия - [ана-то-мия]](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/syllable/close_syllable.scs
+++ b/grammar/phonetics/syllable/close_syllable.scs
@@ -1,0 +1,32 @@
+close_syllable
+<-sc_node_not_relation;;
+close_syllable => nrel_main_idtf:
+	[закрытый слог](* <-lang_ru;; *);
+    [close syllable](* <-lang_en;; *);;
+close_syllable <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: закрытый слог] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: close syllable] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Закрытый слог – называется слог, оканчивающийся неслоговым звуком.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Close syllable is called the syllable terminating in an asyllabical sound.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+                -> syllable;;
+            *);;
+		*);;
+
+close_syllable -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [там - [там]](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/syllable/covered_syllable.scs
+++ b/grammar/phonetics/syllable/covered_syllable.scs
@@ -1,0 +1,32 @@
+covered_syllable
+<-sc_node_not_relation;;
+covered_syllable => nrel_main_idtf:
+	[прикрытый слог](* <-lang_ru;; *);
+    [covered syllable](* <-lang_en;; *);;
+covered_syllable <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: прикрытый слог] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: covered syllable] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Прикрытый слог – называется слог, начинающийся на согласный звук.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Covered syllable is called the syllable beginning on a consonant.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+                -> syllable;;
+            *);;
+		*);;
+
+covered_syllable -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [батон - [ба-тон]](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/syllable/initial_syllable.scs
+++ b/grammar/phonetics/syllable/initial_syllable.scs
@@ -1,0 +1,32 @@
+initial_syllable
+<-sc_node_not_relation;;
+initial_syllable => nrel_main_idtf:
+	[начальный слог](* <-lang_ru;; *);
+    [initial syllable](* <-lang_en;; *);;
+initial_syllable <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: начальный слог] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: initial syllable] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Начальный слог слова может начинаться с любого согласного, с сочетания двух согласных.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The initial syllable of a word can begin with any concordant, with a combination of two concordants.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> consonant_sound;;
+                -> syllable;;
+            *);;
+		*);;
+
+initial_syllable -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [враг - [враг]](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/syllable/not_initial_syllable.scs
+++ b/grammar/phonetics/syllable/not_initial_syllable.scs
@@ -1,0 +1,31 @@
+not_initial_syllable
+<-sc_node_not_relation;;
+not_initial_syllable => nrel_main_idtf:
+	[неначальный слог](* <-lang_ru;; *);
+    [not initial syllable](* <-lang_en;; *);;
+not_initial_syllable <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: неначальный слог] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: not initial syllable] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Неначальный слог словоформы строится по принципу восходящей звучности.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Not initial syllable of a word form is based on the principle of the ascending sonority.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> syllable;;
+            *);;
+		*);;
+
+not_initial_syllable -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [ра­са - [ра-са]](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/syllable/open_syllable.scs
+++ b/grammar/phonetics/syllable/open_syllable.scs
@@ -1,0 +1,32 @@
+open_syllable
+<-sc_node_not_relation;;
+open_syllable => nrel_main_idtf:
+	[открытый слог](* <-lang_ru;; *);
+    [open syllable](* <-lang_en;; *);;
+open_syllable <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: открытый слог] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: open syllable] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Открытый слог – называется слог, оканчивающийся слогообразующим звуком.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Open syllable is called the syllable terminating in a syllabic sound.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+                -> syllable;;
+            *);;
+		*);;
+
+open_syllable -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [вата - [ва-та]](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/syllable/syllable.scs
+++ b/grammar/phonetics/syllable/syllable.scs
@@ -1,0 +1,48 @@
+syllable
+<-sc_node_not_relation;;
+syllable => nrel_main_idtf:
+	[слог](* <-lang_ru;; *);
+    [syllable](* <-lang_en;; *);;
+syllable <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: слог] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: syllable] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Слог представляет собой звук или несколько звуков, произносимых одним выдыхательным толчком. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Syllable represents a sound or several sounds said by one expiratory push.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+            *);;
+		*);;
+
+syllable -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [одессит - [о/де/сит]](*<- lang_ru;;*);;
+    *);;
+
+syllable <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку типа](*<-lang_ru;; *);
+		[Subdividing based on type](*<-lang_en;; *);;
+	-> open_syllable; close_syllable; covered_syllable; uncovered_syllable; initial_syllable; not_initial_syllable;;
+*);;
+
+syllable <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку ударности](*<-lang_ru;; *);
+		[Subdividing based on accent](*<-lang_en;; *);;
+	-> accent_syllable; unaccent_syllable;;
+*);;

--- a/grammar/phonetics/syllable/unaccent_syllable.scs
+++ b/grammar/phonetics/syllable/unaccent_syllable.scs
@@ -1,0 +1,32 @@
+unaccent_syllable
+<-sc_node_not_relation;;
+unaccent_syllable => nrel_main_idtf:
+	[безударный слог](* <-lang_ru;; *);
+    [unaccent syllable](* <-lang_en;; *);;
+unaccent_syllable <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: безударный слог] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: unaccent syllable] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Безударный слог - все слоги в слове,которые не являются ударными. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Unaccent syllable - all syllables in a word which are not accent.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> syllable;;
+                -> accent_syllable;;
+            *);;
+		*);;
+
+unaccent_syllable -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [салфетка - [сал-фет-ка]](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phonetics/syllable/uncovered_syllable.scs
+++ b/grammar/phonetics/syllable/uncovered_syllable.scs
@@ -1,0 +1,32 @@
+uncovered_syllable
+<-sc_node_not_relation;;
+uncovered_syllable => nrel_main_idtf:
+	[неприкрытый слог](* <-lang_ru;; *);
+    [uncovered syllable](* <-lang_en;; *);;
+uncovered_syllable <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: неприкрытый слог] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: uncovered syllable] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Неприкрытый слог – называется слог, начинающийся на гласный звук.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Uncovered syllable is called the syllable beginning on a vowel.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> sound;;
+                -> syllable;;
+            *);;
+		*);;
+
+uncovered_syllable -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [аорта - [а-орта]](*<- lang_ru;;*);;
+    *);;
+

--- a/grammar/phraseology/collocation.scs
+++ b/grammar/phraseology/collocation.scs
@@ -1,0 +1,27 @@
+collocation
+<-sc_node_not_relation;
+<-steady_expression;;
+collocation => nrel_main_idtf:
+	[коллокация](* <-lang_ru;; *);
+    [collocation](* <-lang_en;; *);;
+collocation <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: коллокация] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: collocation] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Коллокацией называется полуфраземой.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Сollocation is a sub-type of phraseme.](*<- lang_en;;*);;
+			*);;
+		*);;
+
+collocation-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [свежий ветер](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phraseology/idiom.scs
+++ b/grammar/phraseology/idiom.scs
@@ -1,0 +1,32 @@
+idiom
+<-sc_node_not_relation;
+<-steady_expression;;
+idiom => nrel_main_idtf:
+	[идиома](* <-lang_ru;; *);
+    [idiom](* <-lang_en;; *);;
+idiom <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: идиома] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: idiom] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Идиома - это лексически неделимые словосочетания, значение которых не определяется значением входящих в них отдельных слов.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[An idiom is lexically indivisible phrases which value is not defined by value of the separate words entering them.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> word;;
+                -> phrase;;
+            *);;
+		*);;
+
+idiom -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [с бухты-барахты - «необдуманно»](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phraseology/phraseological_combination.scs
+++ b/grammar/phraseology/phraseological_combination.scs
@@ -1,0 +1,27 @@
+phraseological_combination
+<-sc_node_not_relation;
+<-steady_expression;;
+phraseological_combination => nrel_main_idtf:
+	[фразеологическое сочетание](* <-lang_ru;; *);
+    [phraseological combination](* <-lang_en;; *);;
+phraseological_combination <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: фразеологическое сочетание] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: phraseological combination] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Фразеологическими сочетаниями называются такие устойчивые обороты, общее значение которых полностью зависит от значения составляющих слов. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Phraseological combinations are called such steady clauses which general meaning completely depends on value of the making words.](*<- lang_en;;*);;
+			*);;
+		*);;
+
+phraseological_combination-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [тоска берет](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phraseology/phraseological_union.scs
+++ b/grammar/phraseology/phraseological_union.scs
@@ -1,0 +1,27 @@
+phraseological_union
+<-sc_node_not_relation;
+<-steady_expression;;
+phraseological_union => nrel_main_idtf:
+	[фразеологическое сращение](* <-lang_ru;; *);
+    [phraseological union](* <-lang_en;; *);;
+phraseological_union <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: фразеологическое сращение] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: phraseological union] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Фразеологическими сращениями называются такие лексически неделимые словосочетания, значение которых не определяется значением входящих в них отдельных слов. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Phraseological unions are called such lexically indivisible phrases which value is not defined by value of the separate words entering them.](*<- lang_en;;*);;
+			*);;
+		*);;
+
+phraseological_union-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [спустя рукава(небрежно)](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phraseology/phraseological_unit.scs
+++ b/grammar/phraseology/phraseological_unit.scs
@@ -1,0 +1,49 @@
+phraseological_unit
+<-sc_node_not_relation;;
+phraseological_unit => nrel_main_idtf:
+	[фразеологизм](* <-lang_ru;; *);
+    [phraseological unit](* <-lang_en;; *);;
+phraseological_unit <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: фразеологизм] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: phraseological unit] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Фразеологизм — устойчивое по составу и структуре, лексически неделимое и целостное по значению словосочетание или предложение, выполняющее функцию отдельной лексемы.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Phraseological unit — steady on structure and structure, lexically the phrase or the offer, indivisible and complete on value, performing function of a separate lexeme.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> lexeme;;
+                -> phrase;;
+                -> sentense;;
+            *);;
+		*);;
+
+phraseological_unit -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [дело в шляпе](*<- lang_ru;;*);;
+    *);;
+
+phraseological_unit <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку функциональной направленности:](*<-lang_ru;; *);
+		[Subdividing based on functional orientation](*<-lang_en;; *);;
+	-> unambiguous_clause; polysemantic_clause;;
+*);;
+phraseological_unit <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку значения:](*<-lang_ru;; *);
+		[Subdividing based on value](*<-lang_en;; *);;
+	-> phraseological_union; phraseological_unity; phraseological_combination;;
+*);;

--- a/grammar/phraseology/phraseological_unity.scs
+++ b/grammar/phraseology/phraseological_unity.scs
@@ -1,0 +1,27 @@
+phraseological_unity
+<-sc_node_not_relation;
+<-steady_expression;;
+phraseological_unity => nrel_main_idtf:
+	[фразеологическое единство](* <-lang_ru;; *);
+    [phraseological unity](* <-lang_en;; *);;
+phraseological_unity <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: фразеологическое единство] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: phraseological unity] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Фразеологическими единствами называются такие лексически неделимые обороты, общее значение которых в какой-то мере мотивировано переносным значением слов, составляющих данный оборот. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Phraseological unities are called such lexically indivisible clauses which general meaning to some extent motivated figurative sense of the words making this clause.](*<- lang_en;;*);;
+			*);;
+		*);;
+
+phraseological_unity-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [плыть по течению](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phraseology/phraseology.scs
+++ b/grammar/phraseology/phraseology.scs
@@ -1,0 +1,37 @@
+phraseology
+<-sc_node_not_relation;;
+phraseology => nrel_main_idtf:
+	[фразеология](* <-lang_ru;; *);
+    [phraseology](* <-lang_en;; *);;
+phraseology <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: фразеология] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: phraseology] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Фразеологией русского языка называется раздел науки о языке, изучающая устойчивые сочетания слов русского языка. ](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Phraseology of Russian is called the division of science about language, studying steady combinations of words of Russian.](*<- lang_en;;*);;
+			*);;
+		*);;
+
+phraseology <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку функциональной направленности:](*<-lang_ru;; *);
+		[Subdividing based on functional orientation:](*<-lang_en;; *);;
+	-> unambiguous_clause; polysemantic_clause;;
+*);;
+phraseology <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку социального употребления](*<-lang_ru;; *);
+		[Subdividing based on social using](*<-lang_en;; *);;
+	-> idiom; proverb; saying; collocation;;
+*);;

--- a/grammar/phraseology/polysemantic_clause.scs
+++ b/grammar/phraseology/polysemantic_clause.scs
@@ -1,0 +1,27 @@
+polysemantic_clause
+<-sc_node_not_relation;
+<-steady_expression;;
+polysemantic_clause => nrel_main_idtf:
+	[многозначный оборот](* <-lang_ru;; *);
+    [polysemantic clause](* <-lang_en;; *);;
+polysemantic_clause <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: многозначный оборот] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: polysemantic clause] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Многозначный оборот - фразеологический оборот, имеющий более одного значения.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Polysemantic clause - set phrase which has more than one value.](*<- lang_en;;*);;
+			*);;
+		*);;
+
+polysemantic_clause -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [висеть в воздухе](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phraseology/proverb.scs
+++ b/grammar/phraseology/proverb.scs
@@ -1,0 +1,27 @@
+proverb
+<-sc_node_not_relation;
+<-steady_expression;;
+proverb => nrel_main_idtf:
+	[пословица](* <-lang_ru;; *);
+    [proverb](* <-lang_en;; *);;
+proverb <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: пословица] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: proverb] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[К пословицам относятся малые формы народного поэтического творчества, облеченные в краткое, ритмизованное изречение, несущее обобщённую мысль, вывод, иносказание с дидактическим уклоном.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[The small forms of folk poetic art invested with the short, metrical saying bearing the generalized thought, a conclusion, an allegory with a didactic bias belong to proverbs.](*<- lang_en;;*);;
+			*);;
+		*);;
+
+proverb-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [баран бараном, а рога даром](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phraseology/saying.scs
+++ b/grammar/phraseology/saying.scs
@@ -1,0 +1,27 @@
+saying
+<-sc_node_not_relation;
+<-steady_expression;;
+saying => nrel_main_idtf:
+	[поговорка](* <-lang_ru;; *);
+    [saying](* <-lang_en;; *);;
+saying <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: поговорка] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: saying] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Поговорка- ходячее выражение, недоразвившееся до полной пословицы, новый образ, замещающий обычное слово.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Saying - the current expression which remained undeveloped to a full proverb, the new image replacing a usual word.](*<- lang_en;;*);;
+			*);;
+		*);;
+
+saying-> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [на одном гвозде всего не повесишь](*<- lang_ru;;*);;
+    *);;

--- a/grammar/phraseology/steady_expression.scs
+++ b/grammar/phraseology/steady_expression.scs
@@ -1,0 +1,40 @@
+steady_expression
+<-sc_node_not_relation;;
+steady_expression => nrel_main_idtf:
+	[устойчивое выражение](* <-lang_ru;; *);
+    [steady expression](* <-lang_en;; *);;
+steady_expression <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: устойчивое выражение] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: steady expression] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Устойчивыми выражениями называют слова вошедшие в лексику из исторических либо литературных источников и получившие широкое распространение благодаря своей выразительности. Изучаются фразеологией.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Steady expressions are the words which entered lexicon from historical or references and widely adopted thanks to the expressiveness. Studied by phraseology.](*<- lang_en;;*);;
+			*);;
+            <= nrel_using_constants: ...
+            (*
+                -> phraseology;;
+            *);;
+		*);;
+
+steady_expression -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [сгорать от стыда](*<- lang_ru;;*);
+            [to be burned with a shame](*<- lang_en;;*);;
+    *);;
+
+steady_expression <= nrel_subdividing: ...
+(*
+	<- explanation;;
+	=> nrel_main_idtf:
+		[Разбиение по признаку социального употребления](*<-lang_ru;; *);
+		[Subdividing based on social using](*<-lang_en;; *);;
+	-> idiom; proverb; saying; collocation;;
+*);;

--- a/grammar/phraseology/unambiguous_clause.scs
+++ b/grammar/phraseology/unambiguous_clause.scs
@@ -1,0 +1,27 @@
+unambiguous_clause
+<-sc_node_not_relation;
+<-steady_expression;;
+unambiguous_clause => nrel_main_idtf:
+	[однозначный оборот](* <-lang_ru;; *);
+    [unambiguous clause](* <-lang_en;; *);;
+unambiguous_clause <- rrel_key_sc_element: 
+		... 
+		(*
+		<- sc_definition;;
+		=> nrel_main_idtf: [Определение: однозначный оборот] (* <- lang_ru;; *);;
+		=> nrel_main_idtf: [Definition: unambiguous clause] (* <- lang_en;; *);;
+        <- definition;;
+		<= nrel_sc_text_translation: ...
+			(*
+			-> rrel_example: 
+				[Однозначный оборот - фразеологический оборот, имеющий единственное значение.](*<- lang_ru;;*);;
+			-> rrel_example: 
+				[Unambiguous clause - set phrase which has a unique value.](*<- lang_en;;*);;
+			*);;
+		*);;
+
+unambiguous_clause -> rrel_example: ...
+    (*
+        => nrel_main_idtf: 
+            [ахиллесова пята](*<- lang_ru;;*);;
+    *);;

--- a/grammar/syntax/adverbial_participle_clause/adverbial_participle_clause.scs
+++ b/grammar/syntax/adverbial_participle_clause/adverbial_participle_clause.scs
@@ -41,7 +41,7 @@ adverbial_participle_clause <- rrel_key_sc_element:...
 adverbial_participle_clause <- rrel_key_sc_element:...
 		(*
         <- explanation;;
-        -> rrel_key_sc_element: adverbial participle clause; rrel_main_word; rrel_minor_word;;
+        -> rrel_key_sc_element: adverbial_participle_clause; rrel_main_word; rrel_minor_word;;
 		=> nrel_main_idtf: 
             [Утв.(деепричастный оборот, главное слово, зависимое слово)] (* <- lang_ru;; *);
             [Expl.(adverbial participle clause, main word, minor word)] (* <- lang_eng;; *);;

--- a/temp_nrels.scs
+++ b/temp_nrels.scs
@@ -18,10 +18,10 @@ kind
     [добрый*](* <-lang_ru;; *);
     [kind*](* <-lang_en;; *);;
         
-sound
+sounding
  => nrel_main_idtf:
     [звучание*](* <-lang_ru;; *);
-    [sound*](* <-lang_en;; *);;
+    [sounding*](* <-lang_en;; *);;
 opposite_meaning
  <- sc_node_norole_relation;
  => nrel_main_idtf:


### PR DESCRIPTION
Изменила название временного идентификатора "звучание*" и, соответственно, изменила его в местах, где он используется.
Создана иерархия понятий "звук", "слог", "фразеологизм" и "ударение".
Исправление ошибки в "деепричастный оборот".
Вроде все)))